### PR TITLE
neighbors().detach(), WalkNeighbors, and misc changes in preparation for 0.2; Part IV

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,34 @@ __ http://bluss.github.io/petulant-avenger-graphlibrary/
 Recent Changes
 --------------
 
+- 0.2.0
+
+  - New Features
+
+    - Add Graph::neighbors().detach() to step edges without borrowing.
+      This is more general than, and replaces now deprecated
+      walk_edges_directed. (#39)
+    - Implement Default for Graph, GraphMap
+    - Add method EdgeDirection::opposite()
+
+  - Breaking changes
+
+    - Graph::neighbors() for undirected graphs and Graph::neighbors_undirected
+      for any graph now visit self loop edges once, not twice. (#31)
+    - Renamed Graph::without_edges to Graph::externals
+    - GraphMap::add_edge now returns ``Option<E>``
+    - Element type of ``GraphMap<N, E>::all_edges()`` changed to ``(N, N, &E)``
+
+  - Minor breaking changes
+
+    - IntoWeightedEdge changed a type parameter to associated type
+    - IndexType is now an unsafe trait
+    - Removed IndexType::{one, zero}, use method new instead.
+    - Removed MinScored
+    - Ptr moved to the graphmap module.
+    - Directed, Undirected are now void enums.
+    - Fields of graphmap::Edges are now private (#19)
+
 - 0.1.18
 
   - Fix bug on calling GraphMap::add_edge with existing edge (#35)

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1004,10 +1004,10 @@ impl<N, E, Ty=Directed, Ix=DefIndex> Graph<N, E, Ty, Ix>
     ///     (2, 3),
     /// ]);
     /// ```
-    pub fn from_edges<I, J>(iterable: I) -> Self
+    pub fn from_edges<I>(iterable: I) -> Self
         where I: IntoIterator,
-              I::Item: IntoWeightedEdge<J, E>,
-              J: Into<NodeIndex<Ix>>,
+              I::Item: IntoWeightedEdge<E>,
+              <I::Item as IntoWeightedEdge<E>>::NodeId: Into<NodeIndex<Ix>>,
               N: Default,
     {
         let mut g = Self::with_capacity(0, 0);
@@ -1022,10 +1022,10 @@ impl<N, E, Ty=Directed, Ix=DefIndex> Graph<N, E, Ty, Ix>
     /// or they are filled with default values.
     ///
     /// Nodes are inserted automatically to match the edges.
-    pub fn extend_with_edges<I, J>(&mut self, iterable: I)
+    pub fn extend_with_edges<I>(&mut self, iterable: I)
         where I: IntoIterator,
-              I::Item: IntoWeightedEdge<J, E>,
-              J: Into<NodeIndex<Ix>>,
+              I::Item: IntoWeightedEdge<E>,
+              <I::Item as IntoWeightedEdge<E>>::NodeId: Into<NodeIndex<Ix>>,
               N: Default,
     {
         let iter = iterable.into_iter();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1342,6 +1342,14 @@ impl<N, E, Ty, Ix> IndexMut<EdgeIndex<Ix>> for Graph<N, E, Ty, Ix> where
     }
 }
 
+/// Create a new empty `Graph`.
+impl<N, E, Ty, Ix> Default for Graph<N, E, Ty, Ix>
+    where Ty: EdgeType,
+          Ix: IndexType,
+{
+    fn default() -> Self { Self::with_capacity(0, 0) }
+}
+
 /// A  `GraphIndex` is a node or edge index.
 pub trait GraphIndex : Copy {
     #[doc(hidden)]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -632,7 +632,15 @@ impl<N, E, Ty=Directed, Ix=DefIndex> Graph<N, E, Ty, Ix>
 
     /// Return an iterator of all nodes with an edge starting from `a`.
     ///
+    /// - `Undirected`: All edges from or to `a`.
+    /// - `Directed`: All edges from `a` (outgoing edges).
+    ///
     /// Produces an empty iterator if the node doesn't exist.
+    ///
+    /// Use [`.neighbors(a).detach()`][1] to get a neighbor walker that does
+    /// not borrow from the graph.
+    ///
+    /// [1]: struct.Neighbors.html#method.detach
     ///
     /// Iterator element type is `NodeIndex<Ix>`.
     pub fn neighbors(&self, a: NodeIndex<Ix>) -> Neighbors<E, Ix>
@@ -644,7 +652,16 @@ impl<N, E, Ty=Directed, Ix=DefIndex> Graph<N, E, Ty, Ix>
     /// in the specified direction.
     /// If the graph's edges are undirected, this is equivalent to *.neighbors(a)*.
     ///
+    /// - `Undirected`: All edges from or to `a`.
+    /// - `Directed`, `Outgoing`: All edges from `a`.
+    /// - `Directed`, `Incoming`: All edges to `a`.
+    ///
     /// Produces an empty iterator if the node doesn't exist.
+    ///
+    /// Use [`.neighbors_directed(a, dir).detach()`][1] to get a neighbor walker that does
+    /// not borrow from the graph.
+    ///
+    /// [1]: struct.Neighbors.html#method.detach
     ///
     /// Iterator element type is `NodeIndex<Ix>`.
     pub fn neighbors_directed(&self, a: NodeIndex<Ix>, dir: EdgeDirection) -> Neighbors<E, Ix>
@@ -658,7 +675,14 @@ impl<N, E, Ty=Directed, Ix=DefIndex> Graph<N, E, Ty, Ix>
     /// in either direction.
     /// If the graph's edges are undirected, this is equivalent to *.neighbors(a)*.
     ///
+    /// - `Undirected` and `Directed`: All edges from or to `a`.
+    ///
     /// Produces an empty iterator if the node doesn't exist.
+    ///
+    /// Use [`.neighbors_undirected(a).detach()`][1] to get a neighbor walker that does
+    /// not borrow from the graph.
+    ///
+    /// [1]: struct.Neighbors.html#method.detach
     ///
     /// Iterator element type is `NodeIndex<Ix>`.
     pub fn neighbors_undirected(&self, a: NodeIndex<Ix>) -> Neighbors<E, Ix>
@@ -698,7 +722,7 @@ impl<N, E, Ty=Directed, Ix=DefIndex> Graph<N, E, Ty, Ix>
         iter
     }
 
-    /// Return an iterator over the edgs from `a` to its neighbors, then *to* `a` from its
+    /// Return an iterator over the edges from `a` to its neighbors, then *to* `a` from its
     /// neighbors.
     ///
     /// Produces an empty iterator if the node doesn't exist.
@@ -855,17 +879,19 @@ impl<N, E, Ty=Directed, Ix=DefIndex> Graph<N, E, Ty, Ix>
         }
     }
 
-    /// Return a “walker” object that can be used to step through the edges
-    /// of the node `a` in direction `dir`.
+    /// **Deprecated:** Use `.neighbors_directed(a, dir).detach()` instead.
+    ///
+    /// Return a “walker” object that can be used to step through the directed
+    /// edges of the node `a` in direction `dir`.
     ///
     /// Note: The walker does not borrow from the graph, this is to allow mixing
     /// edge walking with mutating the graph's weights.
+    ///
+    /// - `Directed`, `Outgoing`: All edges from `a`.
+    /// - `Directed`, `Incoming`: All edges to `a`.
     pub fn walk_edges_directed(&self, a: NodeIndex<Ix>, dir: EdgeDirection) -> WalkEdges<Ix>
     {
-        let first_edge = match self.nodes.get(a.index()) {
-            None => EdgeIndex::end(),
-            Some(node) => node.next[dir as usize],
-        };
+        let first_edge = self.first_edge(a, dir).unwrap_or(EdgeIndex::end());
         WalkEdges { next: first_edge, direction: dir }
     }
 
@@ -888,8 +914,9 @@ impl<N, E, Ty=Directed, Ix=DefIndex> Graph<N, E, Ty, Ix>
     /// // walk the graph and sum incoming edges into the node weight
     /// let mut dfs = Dfs::new(&gr, a);
     /// while let Some(node) = dfs.next(&gr) {
-    ///     let mut edges = gr.walk_edges_directed(node, Incoming);
-    ///     while let Some(edge) = edges.next(&gr) {
+    ///     // use a walker -- a detached neighbors iterator
+    ///     let mut edges = gr.neighbors_directed(node, Incoming).detach();
+    ///     while let Some(edge) = edges.next_edge(&gr) {
     ///         let (nw, ew) = gr.index_twice_mut(node, edge);
     ///         *nw += *ew;
     ///     }
@@ -1153,7 +1180,14 @@ impl<'a, N: 'a, Ty, Ix> Iterator for Externals<'a, N, Ty, Ix> where
 
 /// Iterator over the neighbors of a node.
 ///
-/// Iterator element type is `NodeIndex`.
+/// Iterator element type is `NodeIndex<Ix>`.
+///
+/// Created with [`.neighbors()`][1], [`.neighbors_directed()`][2] or
+/// [`.neighbors_undirected()`][3].
+///
+/// [1]: struct.Graph.html#method.neighbors
+/// [2]: struct.Graph.html#method.neighbors_directed
+/// [3]: struct.Graph.html#method.neighbors_undirected
 pub struct Neighbors<'a, E: 'a, Ix: 'a = DefIndex> where
     Ix: IndexType,
 {
@@ -1167,6 +1201,25 @@ impl<'a, E, Ix> Iterator for Neighbors<'a, E, Ix> where
 
     fn next(&mut self) -> Option<NodeIndex<Ix>> {
         self.iter.next().map(|(index, _)| index)
+    }
+}
+
+impl<'a, E, Ix> Neighbors<'a, E, Ix>
+    where Ix: IndexType,
+{
+    /// Return a “walker” object that can be used to step through the
+    /// neighbors and edges from the origin node.
+    ///
+    /// Note: The walker does not borrow from the graph, this is to allow mixing
+    /// edge walking with mutating the graph's weights.
+    ///
+    /// - `Undirected`: all edges from or to origin.
+    /// - `Directed`: all outgoing edges from origin.
+    pub fn detach(&self) -> WalkNeighbors<Ix> {
+        WalkNeighbors {
+            skip_start: self.iter.skip_start,
+            next: self.iter.next
+        }
     }
 }
 
@@ -1372,6 +1425,92 @@ impl<Ix: IndexType> GraphIndex for EdgeIndex<Ix> {
     fn is_node_index() -> bool { false }
 }
 
+/// A “walker” object that can be used to step through the edge list of a node.
+///
+/// See [*.detach()*](struct.Neighbors.html#method.detach) for more information.
+///
+/// The walker does not borrow from the graph, so it lets you step through
+/// neighbors or incident edges while also mutating graph weights, as
+/// in the following example:
+///
+/// ```
+/// use petgraph::{Graph, Dfs, Incoming};
+///
+/// let mut gr = Graph::new();
+/// let a = gr.add_node(0.);
+/// let b = gr.add_node(0.);
+/// let c = gr.add_node(0.);
+/// gr.add_edge(a, b, 3.);
+/// gr.add_edge(b, c, 2.);
+/// gr.add_edge(c, b, 1.);
+///
+/// // step through the graph and sum incoming edges into the node weight
+/// let mut dfs = Dfs::new(&gr, a);
+/// while let Some(node) = dfs.next(&gr) {
+///     // use a detached neighbors walker
+///     let mut edges = gr.neighbors_directed(node, Incoming).detach();
+///     while let Some(edge) = edges.next_edge(&gr) {
+///         gr[node] += gr[edge];
+///     }
+/// }
+///
+/// // check the result
+/// assert_eq!(gr[a], 0.);
+/// assert_eq!(gr[b], 4.);
+/// assert_eq!(gr[c], 2.);
+/// ```
+pub struct WalkNeighbors<Ix> {
+    skip_start: NodeIndex<Ix>,
+    next: [EdgeIndex<Ix>; 2],
+}
+
+impl<Ix: IndexType> WalkNeighbors<Ix> {
+    /// Step to the next edge and its endpoint node in the walk for graph `g`.
+    ///
+    /// The next node indices are always the others than the starting point
+    /// where the `WalkNeighbors` value was created.
+    /// For an `Outgoing` walk, the target nodes,
+    /// for an `Incoming` walk, the source nodes of the edge.
+    pub fn next<N, E, Ty: EdgeType>(&mut self, g: &Graph<N, E, Ty, Ix>)
+        -> Option<(EdgeIndex<Ix>, NodeIndex<Ix>)> {
+        // First any outgoing edges
+        match g.edges.get(self.next[0].index()) {
+            None => {}
+            Some(edge) => {
+                let ed = self.next[0];
+                self.next[0] = edge.next[0];
+                return Some((ed, edge.node[1]));
+            }
+        }
+        // Then incoming edges
+        // For an "undirected" iterator (traverse both incoming
+        // and outgoing edge lists), make sure we don't double
+        // count selfloops by skipping them in the incoming list.
+        while let Some(edge) = g.edges.get(self.next[1].index()) {
+            let ed = self.next[1];
+            self.next[1] = edge.next[1];
+            if edge.node[0] != self.skip_start {
+                return Some((ed, edge.node[0]));
+            }
+        }
+        None
+    }
+
+    pub fn next_node<N, E, Ty: EdgeType>(&mut self, g: &Graph<N, E, Ty, Ix>)
+        -> Option<NodeIndex<Ix>>
+    {
+        self.next(g).map(|t| t.1)
+    }
+
+    pub fn next_edge<N, E, Ty: EdgeType>(&mut self, g: &Graph<N, E, Ty, Ix>)
+        -> Option<EdgeIndex<Ix>>
+    {
+        self.next(g).map(|t| t.0)
+    }
+}
+
+/// **Deprecated.**
+///
 /// A “walker” object that can be used to step through the edge list of a node.
 ///
 /// See [*.walk_edges_directed()*](struct.Graph.html#method.walk_edges_directed)

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -428,3 +428,10 @@ impl<N, E> IndexMut<(N, N)> for GraphMap<N, E>
         self.edge_weight_mut(index.0, index.1).expect("GraphMap::index: no such edge")
     }
 }
+
+/// Create a new empty `GraphMap`.
+impl<N, E> Default for GraphMap<N, E>
+    where N: NodeTrait,
+{
+    fn default() -> Self { GraphMap::new() }
+}

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -1,18 +1,19 @@
 //! `GraphMap<N, E>` is an undirected graph where node values are mapping keys.
 
-use std::hash::{Hash};
+use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::iter::Cloned;
 use std::collections::hash_map::{
     Keys,
 };
 use std::collections::hash_map::Iter as HashmapIter;
+use std::hash::{self, Hash};
+use std::iter::Cloned;
+use std::iter::FromIterator;
 use std::slice::{
     Iter,
 };
 use std::fmt;
-use std::iter::FromIterator;
-use std::ops::{Index, IndexMut};
+use std::ops::{Index, IndexMut, Deref};
 
 use IntoWeightedEdge;
 
@@ -435,3 +436,71 @@ impl<N, E> Default for GraphMap<N, E>
 {
     fn default() -> Self { GraphMap::new() }
 }
+
+/// A reference that is hashed and compared by its pointer value.
+///
+/// `Ptr` is used for certain configurations of `GraphMap`,
+/// in particular in the combination where the node type for
+/// `GraphMap` is something of type for example `Ptr(&Cell<T>)`,
+/// with the `Cell<T>` being `TypedArena` allocated.
+pub struct Ptr<'b, T: 'b>(pub &'b T);
+
+impl<'b, T> Copy for Ptr<'b, T> {}
+impl<'b, T> Clone for Ptr<'b, T>
+{
+    fn clone(&self) -> Self { *self }
+}
+
+fn ptr_eq<T>(a: *const T, b: *const T) -> bool {
+    a == b
+}
+
+impl<'b, T> PartialEq for Ptr<'b, T>
+{
+    /// Ptr compares by pointer equality, i.e if they point to the same value
+    fn eq(&self, other: &Ptr<'b, T>) -> bool {
+        ptr_eq(self.0, other.0)
+    }
+}
+
+impl<'b, T> PartialOrd for Ptr<'b, T>
+{
+    fn partial_cmp(&self, other: &Ptr<'b, T>) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'b, T> Ord for Ptr<'b, T>
+{
+    /// Ptr is ordered by pointer value, i.e. an arbitrary but stable and total order.
+    fn cmp(&self, other: &Ptr<'b, T>) -> Ordering {
+        let a = self.0 as *const _;
+        let b = other.0 as *const _;
+        a.cmp(&b)
+    }
+}
+
+impl<'b, T> Deref for Ptr<'b, T> {
+    type Target = T;
+    fn deref<'a>(&'a self) -> &'a T {
+        self.0
+    }
+}
+
+impl<'b, T> Eq for Ptr<'b, T> {}
+
+impl<'b, T> Hash for Ptr<'b, T>
+{
+    fn hash<H: hash::Hasher>(&self, st: &mut H)
+    {
+        let ptr = (self.0) as *const T;
+        ptr.hash(st)
+    }
+}
+
+impl<'b, T: fmt::Debug> fmt::Debug for Ptr<'b, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -94,7 +94,7 @@ impl<N, E> GraphMap<N, E>
     /// ```
     pub fn from_edges<I>(iterable: I) -> Self
         where I: IntoIterator,
-              I::Item: IntoWeightedEdge<N, E>
+              I::Item: IntoWeightedEdge<E, NodeId=N>
     {
         Self::from_iter(iterable)
     }
@@ -276,7 +276,7 @@ impl<N, E> GraphMap<N, E>
 
 /// Create a new `GraphMap` from an iterable of edges.
 impl<N, E, Item> FromIterator<Item> for GraphMap<N, E>
-    where Item: IntoWeightedEdge<N, E>,
+    where Item: IntoWeightedEdge<E, NodeId=N>,
           N: NodeTrait,
 {
     fn from_iter<I>(iterable: I) -> Self
@@ -294,7 +294,7 @@ impl<N, E, Item> FromIterator<Item> for GraphMap<N, E>
 ///
 /// Nodes are inserted automatically to match the edges.
 impl<N, E, Item> Extend<Item> for GraphMap<N, E>
-    where Item: IntoWeightedEdge<N, E>,
+    where Item: IntoWeightedEdge<E, NodeId=N>,
           N: NodeTrait,
 {
     fn extend<I>(&mut self, iterable: I)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,47 +84,54 @@ impl EdgeType for Undirected {
 /// a triple of source, target, edge weight.
 ///
 /// For `Graph::from_edges` and `GraphMap::from_edges`.
-pub trait IntoWeightedEdge<Ix, E> {
-    fn into_weighted_edge(self) -> (Ix, Ix, E);
+pub trait IntoWeightedEdge<E> {
+    type NodeId;
+    fn into_weighted_edge(self) -> (Self::NodeId, Self::NodeId, E);
 }
 
-impl<Ix, E> IntoWeightedEdge<Ix, E> for (Ix, Ix)
+impl<Ix, E> IntoWeightedEdge<E> for (Ix, Ix)
     where E: Default
 {
+    type NodeId = Ix;
+
     fn into_weighted_edge(self) -> (Ix, Ix, E) {
         let (s, t) = self;
         (s, t, E::default())
     }
 }
 
-impl<Ix, E> IntoWeightedEdge<Ix, E> for (Ix, Ix, E)
+impl<Ix, E> IntoWeightedEdge<E> for (Ix, Ix, E)
 {
+    type NodeId = Ix;
     fn into_weighted_edge(self) -> (Ix, Ix, E) {
         self
     }
 }
 
-impl<'a, Ix, E> IntoWeightedEdge<Ix, E> for (Ix, Ix, &'a E)
+impl<'a, Ix, E> IntoWeightedEdge<E> for (Ix, Ix, &'a E)
     where E: Clone
 {
+    type NodeId = Ix;
     fn into_weighted_edge(self) -> (Ix, Ix, E) {
         let (a, b, c) = self;
         (a, b, c.clone())
     }
 }
 
-impl<'a, Ix, E> IntoWeightedEdge<Ix, E> for &'a (Ix, Ix)
+impl<'a, Ix, E> IntoWeightedEdge<E> for &'a (Ix, Ix)
     where Ix: Copy, E: Default
 {
+    type NodeId = Ix;
     fn into_weighted_edge(self) -> (Ix, Ix, E) {
         let (s, t) = *self;
         (s, t, E::default())
     }
 }
 
-impl<'a, Ix, E> IntoWeightedEdge<Ix, E> for &'a (Ix, Ix, E)
+impl<'a, Ix, E> IntoWeightedEdge<E> for &'a (Ix, Ix, E)
     where Ix: Copy, E: Clone
 {
+    type NodeId = Ix;
     fn into_weighted_edge(self) -> (Ix, Ix, E) {
         self.clone()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,6 @@
 
 extern crate fixedbitset;
 
-use std::cmp::Ordering;
-use std::hash::{self, Hash};
-use std::fmt;
-use std::ops::{Deref};
-
 pub use graph::Graph;
 pub use graphmap::GraphMap;
 
@@ -84,73 +79,6 @@ impl EdgeType for Undirected {
     fn is_directed() -> bool { false }
 }
 
-
-/// A reference that is hashed and compared by its pointer value.
-///
-/// `Ptr` is used for certain configurations of `GraphMap`,
-/// in particular in the combination where the node type for
-/// `GraphMap` is something of type for example `Ptr(&Cell<T>)`,
-/// with the `Cell<T>` being `TypedArena` allocated.
-pub struct Ptr<'b, T: 'b>(pub &'b T);
-
-impl<'b, T> Copy for Ptr<'b, T> {}
-impl<'b, T> Clone for Ptr<'b, T>
-{
-    fn clone(&self) -> Self { *self }
-}
-
-fn ptr_eq<T>(a: *const T, b: *const T) -> bool {
-    a == b
-}
-
-impl<'b, T> PartialEq for Ptr<'b, T>
-{
-    /// Ptr compares by pointer equality, i.e if they point to the same value
-    fn eq(&self, other: &Ptr<'b, T>) -> bool {
-        ptr_eq(self.0, other.0)
-    }
-}
-
-impl<'b, T> PartialOrd for Ptr<'b, T>
-{
-    fn partial_cmp(&self, other: &Ptr<'b, T>) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<'b, T> Ord for Ptr<'b, T>
-{
-    /// Ptr is ordered by pointer value, i.e. an arbitrary but stable and total order.
-    fn cmp(&self, other: &Ptr<'b, T>) -> Ordering {
-        let a = self.0 as *const _;
-        let b = other.0 as *const _;
-        a.cmp(&b)
-    }
-}
-
-impl<'b, T> Deref for Ptr<'b, T> {
-    type Target = T;
-    fn deref<'a>(&'a self) -> &'a T {
-        self.0
-    }
-}
-
-impl<'b, T> Eq for Ptr<'b, T> {}
-
-impl<'b, T> Hash for Ptr<'b, T>
-{
-    fn hash<H: hash::Hasher>(&self, st: &mut H)
-    {
-        let ptr = (self.0) as *const T;
-        ptr.hash(st)
-    }
-}
-
-impl<'b, T: fmt::Debug> fmt::Debug for Ptr<'b, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
 
 /// Convert an element like `(i, j)` or `(i, j, w)` into
 /// a triple of source, target, edge weight.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod quickcheck;
 
 // Index into the NodeIndex and EdgeIndex arrays
 /// Edge direction
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub enum EdgeDirection {
     /// An `Outgoing` edge is an outward edge *from* the current node.
     Outgoing = 0,
@@ -47,8 +47,9 @@ pub enum EdgeDirection {
 }
 
 impl EdgeDirection {
+    /// Return the opposite `EdgeDirection`.
     #[inline]
-    fn opposite(&self) -> EdgeDirection {
+    pub fn opposite(&self) -> EdgeDirection {
         match *self {
             Outgoing => Incoming,
             Incoming => Outgoing,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,12 @@
 //! **petgraph** is a graph data structure library.
 //!
 //! The most prominent type is [`Graph`](./graph/struct.Graph.html) which is
-//! a directed or undirected graph with arbitrary associated node and edge data.
+//! an adjacency list graph with undirected or directed edges and arbitrary
+//! associated data.
 //!
 //! Petgraph also provides [`GraphMap`](./graphmap/struct.GraphMap.html) which
-//! is an undirected hashmap-backed graph which only allows simple node identifiers
-//! (such as integers or references).
+//! is an hashmap-backed graph with undirected edges and only allows simple node
+//! identifiers (such as integers or references).
 
 extern crate fixedbitset;
 

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -28,7 +28,7 @@ pub trait Graphlike {
     type NodeId: Clone;
 }
 
-/// A graph trait for accessing the neighbors iterator
+/// NeighborIter gives access to the neighbors iterator.
 pub trait NeighborIter<'a> : Graphlike {
     type Iter: Iterator<Item=Self::NodeId>;
 
@@ -59,7 +59,8 @@ where N: Copy + Ord + Hash
 
 /// Wrapper type for walking the graph as if it is undirected
 pub struct AsUndirected<G>(pub G);
-/// Wrapper type for walking edges the other way
+
+/// Wrapper type for walking the graph as if all edges are reversed.
 pub struct Reversed<G>(pub G);
 
 impl<'a, 'b, N, E: 'a, Ty, Ix> NeighborIter<'a> for AsUndirected<&'b Graph<N, E, Ty, Ix>> where
@@ -146,7 +147,7 @@ impl<'a, 'b,  G> Externals<'a> for Reversed<&'b G>
     }
 }
 
-/// A mapping from node → is_visited.
+/// A mapping for storing the visited status for NodeId `N`.
 pub trait VisitMap<N> {
     /// Return **true** if the value is not already present.
     fn visit(&mut self, N) -> bool;
@@ -188,13 +189,13 @@ impl<N: Eq + Hash> VisitMap<N> for HashSet<N> {
     }
 }
 
-/// Trait for which datastructure to use for a graph’s visitor map
+/// A graph that can create a visitor map.
 pub trait Visitable : Graphlike {
     type Map: VisitMap<Self::NodeId>;
     fn visit_map(&self) -> Self::Map;
 }
 
-/// Trait for graph that can reset & resize its visitor map
+/// A graph that can reset and resize its visitor map.
 pub trait Revisitable : Visitable {
     fn reset_map(&self, &mut Self::Map);
 }


### PR DESCRIPTION
Introduce `.neighbors(a).detach()` and so on to be the replacement for `walk_edges_directed` which will be deprecated.

Closes #27 