### PR TITLE
Remove former method Graph::edges_both; breaking changes Part II

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -704,7 +704,7 @@ impl<N, E, Ty=Directed, Ix=DefIndex> Graph<N, E, Ty, Ix>
     /// Produces an empty iterator if the node doesn't exist.
     ///
     /// Iterator element type is `(NodeIndex<Ix>, &E)`.
-    pub fn edges_undirected(&self, a: NodeIndex<Ix>) -> Edges<E, Ix>
+    fn edges_undirected(&self, a: NodeIndex<Ix>) -> Edges<E, Ix>
     {
         Edges {
             skip_start: a,

--- a/tests/ograph.rs
+++ b/tests/ograph.rs
@@ -1010,9 +1010,9 @@ fn neighbors_selfloops() {
     seen_undir.sort();
     assert_eq!(&seen_undir, &undir_edges);
 
-    let mut seen_undir = gr.edges_undirected(a).map(|(x, _)| x).collect::<Vec<_>>();
-    seen_undir.sort();
-    assert_eq!(&seen_undir, &undir_edges);
+    let mut seen_out = gr.edges(a).map(|(x, _)| x).collect::<Vec<_>>();
+    seen_out.sort();
+    assert_eq!(&seen_out, &out_edges);
 
     // Undirected graph
     let mut gr: Graph<_, (), _> = Graph::new_undirected();


### PR DESCRIPTION
This seems to be of little use. Instead of renaming it (for
consistency), simply remove it.

Part of issue #27 