### PR TITLE
Fix Kosaraju and add a test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["data-structure", "graph", "unionfind", "graph-algorithms"]
 [lib]
 
 name = "petgraph"
+bench = false
 
 [profile.release]
 

--- a/tests/ograph.rs
+++ b/tests/ograph.rs
@@ -582,6 +582,20 @@ fn scc() {
     assert_sccs_eq(petgraph::algo::scc(&gr), vec![
         vec![n(0)], vec![n(1)], vec![n(2)], vec![n(3)],
     ]);
+
+    // Kosaraju bug from PR #60
+    let mut gr = Graph::<(), ()>::new();
+    gr.extend_with_edges(&[
+        (0, 0),
+        (1, 0),
+        (2, 0),
+        (2, 1),
+        (2, 2),
+    ]);
+    gr.add_node(());
+    assert_sccs_eq(petgraph::algo::scc(&gr), vec![
+        vec![n(0)], vec![n(1)], vec![n(2)], vec![n(3)],
+    ]);
 }
 
 #[test]


### PR DESCRIPTION
Include the fix in #60.

Add a second implementation (Tarjan's algorithm) in quickcheck, and use quickcheck to check the two algorithms against each other. 

Quickcheck found a much smaller counterexample.

Old result said sccs are (0), (1 2), (3)  
Correct answer is (0), (1), (2), (3).

![scc counterexample](http://i.imgur.com/fM5dn0c.png)

I verfied that #60 fixed this counterexample, and of course it passes all quickcheck trials I have run. Now we have much better confidence that the algorithm is correct!